### PR TITLE
Stripping unicode character symbols in webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,11 @@ When using browserify you might want to remove the symbols table from your bundl
 # Generates a standalone slug browser bundle:
 browserify slug.js --ignore unicode/category/So -s slug > slug-browser.js
 ```
+
+When using webpack you can use:
+```javascript
+externals: {
+    'unicode/category/So': '{}',
+}
+```
+In your webpack config to replace the require with an empty object stub.


### PR DESCRIPTION
Hi,

Thanks for maintaining this fork. Here are some instructions for stripping the unicode symbols in webpack. I'm not experienced enough to know if this is exactly the best way but it is a start and seems to do the job.

Just want to help others in my position.

Cheers,
Michael
